### PR TITLE
Remove repository id from store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.1] - 2020-07-01
+## Unreleased
+### Changed
+- Data is not stored using the repository id as key ([#4](https://github.com/scm-manager/scm-pushlog-plugin/pull/4))
+
+## 2.1.1 - 2020-07-01
 ### Fixed
 - Add missing translations
 
-## [2.1.0] - 2020-06-18
+## 2.1.0 - 2020-06-18
 ### Changed
 - Add "Pushed-by" as contributor to changset ([#3](https://github.com/scm-manager/scm-pushlog-plugin/pull/3)) 
 
-## [2.0.0] - 2020-06-04
+## 2.0.0 - 2020-06-04
 ### Changed
 - Changeover to MIT license ([#2](https://github.com/scm-manager/scm-pushlog-plugin/pull/2))
 - Rebuild for api changes from core

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020-present Cloudogu GmbH and Contributors
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,7 +28,7 @@ plugins {
 }
 
 scmPlugin {
-  scmVersion = "2.1.0"
+  scmVersion = "2.13.0"
   displayName = "Pushlog"
   description = "Tracks who pushed what to a repository"
   author = "Cloudogu GmbH"

--- a/src/main/java/sonia/scm/pushlog/PushlogManager.java
+++ b/src/main/java/sonia/scm/pushlog/PushlogManager.java
@@ -63,7 +63,7 @@ public class PushlogManager {
       try {
         logger.debug("store pushlog for repository {}",
           pushlog.getRepositoryId());
-        getDatastore(repository).put(pushlog.getRepositoryId(), pushlog);
+        getDatastore(repository).put(NAME, pushlog);
       } finally {
         logger.trace("unlock repository {}", pushlog.getRepositoryId());
         getLock(pushlog.getRepositoryId()).unlock();
@@ -72,7 +72,7 @@ public class PushlogManager {
   }
 
   public Pushlog get(Repository repository) {
-    Pushlog pushlog = getDatastore(repository).get(repository.getId());
+    Pushlog pushlog = getDatastore(repository).get(NAME);
 
     if (pushlog == null) {
       pushlog = new Pushlog(repository.getId());

--- a/src/main/java/sonia/scm/pushlog/update/RemoveRepositoryIdFromStoreUpdateStep.java
+++ b/src/main/java/sonia/scm/pushlog/update/RemoveRepositoryIdFromStoreUpdateStep.java
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package sonia.scm.pushlog.update;
+
+import sonia.scm.migration.UpdateStep;
+import sonia.scm.plugin.Extension;
+import sonia.scm.pushlog.Pushlog;
+import sonia.scm.store.DataStore;
+import sonia.scm.store.DataStoreFactory;
+import sonia.scm.update.RepositoryUpdateIterator;
+import sonia.scm.version.Version;
+
+import javax.inject.Inject;
+
+@Extension
+public class RemoveRepositoryIdFromStoreUpdateStep implements UpdateStep {
+
+  private final RepositoryUpdateIterator repositoryUpdateIterator;
+  private final DataStoreFactory storeFactory;
+
+  @Inject
+  public RemoveRepositoryIdFromStoreUpdateStep(RepositoryUpdateIterator repositoryUpdateIterator, DataStoreFactory storeFactory) {
+    this.repositoryUpdateIterator = repositoryUpdateIterator;
+    this.storeFactory = storeFactory;
+  }
+
+  @Override
+  public void doUpdate()  {
+    repositoryUpdateIterator.forEachRepository(this::doUpdate);
+  }
+
+  private void doUpdate(String repositoryId) {
+    DataStore<Pushlog> store = storeFactory
+      .withType(Pushlog.class)
+      .withName("pushlog")
+      .forRepository(repositoryId)
+      .build();
+    store.getOptional(repositoryId)
+      .ifPresent(pushlog -> moveStore(store, repositoryId, pushlog));
+  }
+
+  private void moveStore(DataStore<Pushlog> store, String repositoryId, Pushlog pushlog) {
+    store.put("pushlog", pushlog);
+    store.remove(repositoryId);
+  }
+
+  @Override
+  public Version getTargetVersion() {
+    return Version.parse("2.0.1");
+  }
+
+  @Override
+  public String getAffectedDataType() {
+    return "sonia.scm.pushlog.data.xml";
+  }
+}

--- a/src/test/java/sonia/scm/pushlog/update/RemoveRepositoryIdFromStoreUpdateStepTest.java
+++ b/src/test/java/sonia/scm/pushlog/update/RemoveRepositoryIdFromStoreUpdateStepTest.java
@@ -1,0 +1,96 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package sonia.scm.pushlog.update;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.pushlog.Pushlog;
+import sonia.scm.store.DataStore;
+import sonia.scm.store.DataStoreFactory;
+import sonia.scm.update.RepositoryUpdateIterator;
+
+import java.util.function.Consumer;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RemoveRepositoryIdFromStoreUpdateStepTest {
+
+  private static final String REPOSITORY_ID = "42";
+
+  @Mock
+  private RepositoryUpdateIterator repositoryUpdateIterator;
+  @Mock(answer = Answers.CALLS_REAL_METHODS)
+  private DataStoreFactory storeFactory;
+  @Mock
+  private DataStore store;
+
+  @InjectMocks
+  private RemoveRepositoryIdFromStoreUpdateStep updateStep;
+
+  @BeforeEach
+  void mockStore() {
+    doAnswer(invocation -> {
+      invocation.getArgument(0, Consumer.class).accept(REPOSITORY_ID);
+      return null;
+    }).when(repositoryUpdateIterator).forEachRepository(any());
+    when(storeFactory.getStore(argThat(parameter ->
+      parameter.getRepositoryId().equals(REPOSITORY_ID)
+        && parameter.getName().equals("pushlog")
+        && parameter.getType().equals(Pushlog.class)))).thenReturn(store);
+  }
+
+  @Test
+  void shouldMoveStoreEntry() {
+    Pushlog pushlog = new Pushlog();
+    when(store.getOptional(REPOSITORY_ID)).thenReturn(of(pushlog));
+
+    updateStep.doUpdate();
+
+    verify(store).remove(REPOSITORY_ID);
+    verify(store).put("pushlog", pushlog);
+  }
+
+  @Test
+  void shouldNotFailForRepositoryWithoutStatistics() {
+    when(store.getOptional(REPOSITORY_ID)).thenReturn(empty());
+
+    updateStep.doUpdate();
+
+    verify(store, never()).remove(any());
+    verify(store, never()).put(any(), any());
+  }
+}

--- a/src/test/java/sonia/scm/pushlog/update/RemoveRepositoryIdFromStoreUpdateStepTest.java
+++ b/src/test/java/sonia/scm/pushlog/update/RemoveRepositoryIdFromStoreUpdateStepTest.java
@@ -85,7 +85,7 @@ class RemoveRepositoryIdFromStoreUpdateStepTest {
   }
 
   @Test
-  void shouldNotFailForRepositoryWithoutStatistics() {
+  void shouldNotFailForRepositoryWithoutPushlog() {
     when(store.getOptional(REPOSITORY_ID)).thenReturn(empty());
 
     updateStep.doUpdate();


### PR DESCRIPTION
## Proposed changes

This is necessary to make the pushlog "exportable".
Using the repository id as a key for the data, this cannot
be imported in other repositories with other ids and
therefore we would loose the existing pushlog.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
